### PR TITLE
Implemented custom hashref keys in the iterators for dropdowns.

### DIFF
--- a/lib/Template/Flute.pm
+++ b/lib/Template/Flute.pm
@@ -1188,6 +1188,56 @@ HTML output:
       <option value="black" selected="selected">Black</option>
       </select>
 
+=head3 Custom iterators for dropdowns
+
+By default, the iterator for a dropdown is an arrayref of hashrefs
+with two hardcoded keys: C<value> and (optionally) C<label>. You can
+override this behaviour in the specification with
+C<iterator_value_key> and C<iterator_name_key> to use your own
+hashref's keys from the iterator, instead of C<value> and C<label>.
+
+Specification:
+
+  <specification>
+    <value name="color" iterator="colors"
+           iterator_value_key="code" iterator_name_key="name"/>
+  </specification>
+
+Template:
+
+  <html>
+   <select class="color">
+   <option value="example">Example</option>
+   </select>
+  </html>
+
+Code:
+
+  @colors = ({code => 'red', name => 'Red'},
+             {code => 'black', name => 'Black'},
+            );
+  
+  $flute = Template::Flute->new(template => $html,
+                                specification => $spec,
+                                iterators => {colors => \@colors},
+                                values => { color => 'black' },
+                               );
+  
+  $out = $flute->process();
+
+Output:
+
+  <html>
+   <head></head>
+   <body>
+    <select class="color">
+     <option value="red">Red</option>
+     <option selected="selected" value="black">Black</option>
+    </select>
+   </body>
+  </html>
+
+
 =head1 LISTS
 
 Lists can be accessed after parsing the specification and the HTML template

--- a/lib/Template/Flute/HTML.pm
+++ b/lib/Template/Flute/HTML.pm
@@ -650,17 +650,29 @@ sub _set_selected {
 		# get options from iterator		
 		$iter->reset();
 		while ($optref = $iter->next()) {
+
+            # determine where to look for labels and values in the iterator
+            my $value_k = "value";
+            my $label_k = "label";
+            if (exists $sob->{iterator_value_key} && $sob->{iterator_value_key}) {
+                $value_k = $sob->{iterator_value_key};
+            }
+            if (exists $sob->{iterator_name_key} && $sob->{iterator_name_key}) {
+                $label_k = $sob->{iterator_name_key};
+            }
+
+
 			my (%att, $text);
 			
-			if (exists $optref->{label}) {
-				$text = $optref->{label};
-				$att{value} = $optref->{value};
+			if (exists $optref->{$label_k}) {
+				$text = $optref->{$label_k};
+				$att{value} = $optref->{$value_k};
 			}
 			else {
-				$text = $optref->{value};
+				$text = $optref->{$value_k};
 			}
 
-			if (defined $value && $optref->{value} eq $value) {
+			if (defined $value && $optref->{$value_k} eq $value) {
 				$att{selected} = 'selected';
 			}
 			

--- a/t/values/select-custom.t
+++ b/t/values/select-custom.t
@@ -1,0 +1,112 @@
+# Dropdown tests for values.
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+use Template::Flute;
+
+my ($spec, $html, @colors, $flute, $out);
+
+$spec = q{<specification>
+<value name="test" iterator="colors" iterator_value_key="code" iterator_name_key="name"/>
+</specification>
+};
+
+$html = q{<html><select class="test"></select></html>};
+
+@colors = ({code => 'red'},
+           {code => 'black'});
+
+$flute = Template::Flute->new(template => $html,
+                              specification => $spec,
+                              iterators => { colors => \@colors },
+                             );
+
+$out = $flute->process();
+
+ok ($out =~ m%<option>red</option><option>black</option>%,
+    "Test value with HTML dropdown.")
+    || diag "HTML: $out.\n";
+
+
+$flute = Template::Flute->new(template => $html,
+                              specification => $spec,
+                              iterators => { colors => \@colors },
+                              values => { test => 'black' },
+                             );
+
+$out = $flute->process();
+
+ok ($out =~ m%<option>red</option><option selected="selected">black</option>%,
+    "Test value with HTML dropdown and selected value.")
+    || diag "HTML: $out.\n";
+
+@colors = ({code => 'red', name => 'Red'},
+           {code => 'black', name => 'Black'},
+          );
+
+$flute = Template::Flute->new(template => $html,
+                              specification => $spec,
+                              iterators => {colors => \@colors},
+                             );
+
+$out = $flute->process();
+
+ok ($out =~ m%<option value="red">Red</option><option value="black">Black</option>%,
+    "Test value with HTML dropdown and labels.")
+    || diag "HTML: $out.\n";
+
+
+$flute = Template::Flute->new(template => $html,
+                              specification => $spec,
+                              iterators => {colors => \@colors},
+                              values => {test => 'black'},
+                             );
+
+$out = $flute->process();
+
+ok ($out =~ m%<option value="red">Red</option><option selected="selected" value="black">Black</option>%,
+    "Test value with HTML dropdown, labels and selected value.")
+    || diag "HTML: $out.\n";
+
+
+$spec =<<'SPEC';
+<specification>
+  <value name="color" iterator="colors"
+         iterator_value_key="code" iterator_name_key="name"/>
+</specification>
+SPEC
+
+$html =<<'HTML';
+<html>
+ <select class="color">
+ <option value="example">Example</option>
+ </select>
+</html>
+HTML
+
+@colors = ({code => 'red', name => 'Red'},
+           {code => 'black', name => 'Black'},
+          );
+
+$flute = Template::Flute->new(template => $html,
+                              specification => $spec,
+                              iterators => {colors => \@colors},
+                              values => { color => 'black' },
+                             );
+
+$out = $flute->process();
+my $expected =<<'HTML';
+<select class="color">
+<option value="red">Red</option>
+<option selected="selected" value="black">Black</option>
+</select></body>
+HTML
+
+$expected =~ s/\n//g;
+
+ok($out =~ m/\Q$expected\E/, "doc example ok") || diag $out;
+
+print $out, "\n";
+


### PR DESCRIPTION
Added two options to the specification:
- iterator_value_key
- iterator_name_key

The option overwrite the hardcoded "value" and "label" (which are kept
as default).

Implemented the lookup of hash keys in the iterators for the dropdown

Doc + changed names
