### PR TITLE
Top level containers should affect lists too.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -95,6 +95,7 @@ t/iterators/01-simple.t
 t/iterators/20-json.t
 t/iterators/paginator.t
 t/lists/append.t
+t/lists/global-containers.t
 t/lists/increments.t
 t/lists/nested.t
 t/lists/object.t

--- a/lib/Template/Flute.pm
+++ b/lib/Template/Flute.pm
@@ -429,6 +429,19 @@ sub _sub_process {
 		push @{$spec_elements->{$type}}, $elt;
 		
 	}	
+
+    # cut the elts in the template, *before* processing the lists
+    if ($level == 0) {
+        for my $container ($template->containers()) {
+            $container->set_values($values) if $values;
+            unless ($container->visible()) {
+                for my $elt (@{$container->elts()}) {
+                    $elt->cut();
+                }
+            }
+        }
+    }
+
 	# List
 	for my $elt ( @{$spec_elements->{list}} ) {
         next if exists $skip{$elt};
@@ -569,17 +582,17 @@ sub _sub_process {
 			$self->_replace_record($spec_name, $values, $spec_class, $spec_class->{elts});
 		}
 	}
-  	
-	
-	for my $container ($template->containers()) {
-		$container->set_values($values) if $values;
-		
-		unless ($container->visible()) {
-		    for my $elt (@{$container->elts()}) {
-			$elt->cut();
-		    }
-		}
-	}
+
+    # cut again the invisible containers, after the values are interpolated
+    if ($level == 0) {
+        for my $container ($template->containers()) {
+            unless ($container->visible()) {
+                for my $elt (@{$container->elts()}) {
+                    $elt->cut();
+                }
+            }
+        }
+    }
 
 	return $count ? $template->{xml}->root() : $template->{xml};	
 }

--- a/t/lists/global-containers.t
+++ b/t/lists/global-containers.t
@@ -1,0 +1,80 @@
+# test for global containers in lists
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use Template::Flute;
+
+my $spec = <<EOF;
+<specification>
+<container name="locked" class="locked" value="locked" />
+<container name="unlocked" class="unlocked" value="!locked" />
+<list name="mylist" iterator="mylist">
+  <param name="title" class="title" />
+</list>
+</specification>
+EOF
+
+my $html =<<EOF;
+<html>
+<body>
+<div>
+  <span class="locked">Locked</span>
+  <span class="unlocked">Unlocked</span>
+</div>
+<ol>
+<li class="mylist">
+  <span class="title">Blablabla</span>
+  <span class="locked">Locked</span>
+  <span class="unlocked">Unlocked</span>
+</li>
+</ol>
+</body>
+</html>
+EOF
+
+my $list = [
+            { title => 1 },
+            { title => 2 },
+            { title => 3 },
+           ];
+
+my $flute = Template::Flute->new(
+                                 template => $html,
+                                 specification => $spec,
+                                 values => {
+                                            mylist => $list,
+                                            locked => 0,
+                                           },
+                                );
+
+my $out = $flute->process;
+
+my $expected = <<EOF;
+<div>
+<span class="unlocked">Unlocked</span>
+</div>
+<ol>
+<li class="mylist">
+<span class="title">1</span>
+<span class="unlocked">Unlocked</span>
+</li>
+<li class="mylist">
+<span class="title">2</span>
+<span class="unlocked">Unlocked</span>
+</li>
+<li class="mylist">
+<span class="title">3</span>
+<span class="unlocked">Unlocked</span>
+</li>
+</ol>
+EOF
+
+$expected =~ s/\n//g;
+
+like $out, qr{\Q$expected\E}, "list is looking good";
+unlike $out, qr{class="locked"};
+
+diag $out;
+


### PR DESCRIPTION
Due to recursion, containers didn't work as expected inside lists.

This change seems to have duplicated code, but it's a minor one.
Actually, it save some CPU cycles, because containers are scanned only
at top level, instead of at each recursion.

The first block cuts the elts before processing values and lists.

The last block assert that previously cut elements are still cut,
because the value processing paste them back (apparently).

No test breaks.
