### PR TITLE
Filter::Currency returns undef for undef amount

### DIFF
--- a/lib/Template/Flute/Filter/Currency.pm
+++ b/lib/Template/Flute/Filter/Currency.pm
@@ -44,6 +44,7 @@ Currency filter.
 sub filter {
     my ($self, $amount) = @_;
 
+    return undef unless defined $amount;
     return $self->{format}->format_price($amount);
 }
 


### PR DESCRIPTION
Otherwise it calls format_price which barfs on undef arg. Should be able to cope with undefined arguments.
