### PR TITLE
Collapse whitespace before i18n

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -137,6 +137,7 @@ t/files/i18n.html
 t/files/i18n.xml
 t/i18n/02-includes.t
 t/i18n/03-attributes.t
+t/i18n/04-whitespace.t
 t/testfiles/bad/admin.html
 t/testfiles/bad/admin.xml
 t/testfiles/bad/checkout-giftinfo.html

--- a/lib/Template/Flute/HTML.pm
+++ b/lib/Template/Flute/HTML.pm
@@ -207,6 +207,11 @@ sub _translate_string {
     }
     # return undef if no text is left
     return unless length($text);
+
+    # collapse the whitespace inside, discarding it for the
+    # purpose of localization.
+    $text =~ s/\s+/ /g;
+
     # translate and restore spaces
     return $ws_before . $i18n->localize($text) . $ws_after;
 }

--- a/t/i18n/04-whitespace.t
+++ b/t/i18n/04-whitespace.t
@@ -1,0 +1,49 @@
+#!perl
+
+use strict;
+use warnings;
+use utf8;
+
+use Test::More tests => 1;
+
+use Template::Flute;
+use Template::Flute::I18N;
+
+my %lexicon = (
+               "Enter your username..." => "Inserisci il nome utente...",
+               "Submit result" => "Invia i risultati",
+               "Title" => "Titolo",
+               "Do-not-translate" => "FAIL",
+               "Please insert your username here and we will send you a reset link." => "Inserisci il tuo nome utente e ti manderemo le istruzioni",
+              );
+
+sub translate {
+    my $text = shift;
+    return $lexicon{$text};
+};
+
+my $i18n = Template::Flute::I18N->new(\&translate);
+
+my $spec = '<specification></specification>';
+my $template =<<HTML;
+<html>
+<body>
+<div>
+<p>
+    Please insert your username here and we will send you a reset
+    link.
+</p>
+</div>
+</body>
+</html>
+HTML
+
+my $flute = Template::Flute->new(specification => $spec,
+                                 template => $template,
+                                 i18n => $i18n);
+my $output = $flute->process();
+
+# diag $output;
+
+like $output, qr{\sInserisci il tuo nome utente e ti manderemo le istruzioni\s},
+  "White space collapsed and string translated";


### PR DESCRIPTION
Leading and trailing whitespace is kept, while the whitespaces inside the
strings are collapsed to a single space.

This should close https://github.com/racke/Template-Flute/issues/83
