### PR TITLE
Remove the bom when processing files

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -78,6 +78,7 @@ t/filters/upper.t
 t/values/append.t
 t/values/bad_objects.t
 t/values/basic.t
+t/values/bom.t
 t/values/checkboxes.t
 t/values/hook-script.t
 t/values/input.t
@@ -141,6 +142,10 @@ t/test-twig.t
 t/uri-adjust.t
 t/files/i18n.html
 t/files/i18n.xml
+t/files/bom.xml
+t/files/bom.html
+t/files/bom-included.xml
+t/files/bom-included.html
 t/i18n/02-includes.t
 t/i18n/03-attributes.t
 t/i18n/04-whitespace.t

--- a/lib/Template/Flute/HTML.pm
+++ b/lib/Template/Flute/HTML.pm
@@ -372,6 +372,10 @@ sub _parse_template {
 		$self->{file} = $template;
 		$encoding = $spec_object->encoding();
 		$html_content = Path::Tiny::path($template)->slurp({binmode => ":encoding($encoding)"});
+        my $first_char = substr($html_content, 0, 1);
+        if ($first_char eq "\x{feff}") {
+            substr($html_content, 0, 1, '');
+        }
 		unless ($encoding eq 'utf8') {
 			$html_content = encode('utf8', $html_content);
 		}

--- a/t/files/bom-included.html
+++ b/t/files/bom-included.html
@@ -1,0 +1,1 @@
+﻿<div>This snippet is included.</div>

--- a/t/files/bom-included.xml
+++ b/t/files/bom-included.xml
@@ -1,0 +1,2 @@
+<specification>
+</specification>

--- a/t/files/bom.html
+++ b/t/files/bom.html
@@ -1,0 +1,1 @@
+﻿<div>This is a test.<div class="included"></div></div>

--- a/t/files/bom.xml
+++ b/t/files/bom.xml
@@ -1,0 +1,3 @@
+<specification>
+  <value name="included" include="bom-included.html" />
+</specification>

--- a/t/values/bom.t
+++ b/t/values/bom.t
@@ -1,0 +1,33 @@
+#!perl
+
+use utf8;
+use strict;
+use warnings;
+
+use Template::Flute;
+use Path::Tiny;
+use File::Spec;
+use Test::More tests => 4;
+use Data::Dumper;
+
+my $builder = Test::More->builder;
+binmode $builder->output,         ":utf8";
+binmode $builder->failure_output, ":utf8";
+binmode $builder->todo_output,    ":utf8";
+
+
+foreach my $html_file ('bom.html', 'bom-included.html') {
+    my $target = File::Spec->catfile(qw/t files/, $html_file);
+    my $html_in = Path::Tiny::path($target)->slurp({ binmode => ':encoding(utf-8)' });
+    like $html_in, qr/\A\x{feff}/, "Bom present in $target";
+}
+
+my $flute = Template::Flute->new(specification_file => 't/files/bom.xml',
+                                 template_file => 't/files/bom.html');
+
+
+my $out = $flute->process;
+unlike $out, qr/\x{feff}/, "Bom not present in output" or diag Dumper($out);
+is ($out,
+    '<html><head></head><body><div>This is a test.<div class="included"><div>This snippet is included.</div></div></div></body></html>',
+    'output correct');


### PR DESCRIPTION
This cause random breakages in the layout which are hard to catch because
the BOM is not a visible character