### PR TITLE
Update copyright statements

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2010-2015 by Stefan Hornburg (Racke).
+This software is Copyright (c) 2010-2015 by Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This is free software, licensed under:
 
@@ -270,7 +270,7 @@ That's all there is to it!
 
 --- The Artistic License 1.0 ---
 
-This software is Copyright (c) 2010-2015 by Stefan Hornburg (Racke).
+This software is Copyright (c) 2010-2015 by Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This is free software, licensed under:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is copyright (c) 2010-2012 by Stefan Hornburg (Racke).
+This software is copyright (c) 2010-2015 by Stefan Hornburg (Racke).
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2010-2012 by Stefan Hornburg (Racke).
+This software is Copyright (c) 2010-2015 by Stefan Hornburg (Racke).
 
 This is free software, licensed under:
 
@@ -270,7 +270,7 @@ That's all there is to it!
 
 --- The Artistic License 1.0 ---
 
-This software is Copyright (c) 2010-2012 by Stefan Hornburg (Racke).
+This software is Copyright (c) 2010-2015 by Stefan Hornburg (Racke).
 
 This is free software, licensed under:
 

--- a/README
+++ b/README
@@ -965,7 +965,7 @@ HISTORY
     module.
 
 LICENSE AND COPYRIGHT
-    Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+    Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
     This program is free software; you can redistribute it and/or modify it
     under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute.pm
+++ b/lib/Template/Flute.pm
@@ -2376,7 +2376,7 @@ a request from Matt S. Trout, author of the L<HTML::Zoom> module.
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Config.pm
+++ b/lib/Template/Flute/Config.pm
@@ -36,7 +36,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Container.pm
+++ b/lib/Template/Flute/Container.pm
@@ -138,7 +138,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Database/Rose.pm
+++ b/lib/Template/Flute/Database/Rose.pm
@@ -104,7 +104,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter.pm
+++ b/lib/Template/Flute/Filter.pm
@@ -52,7 +52,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2011 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2011-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/Boolean.pm
+++ b/lib/Template/Flute/Filter/Boolean.pm
@@ -35,7 +35,7 @@ Grega Pompe <grega.pompe@informa.si>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2013-2014 Grega Pompe <grega.pompe@informa.si>
+Copyright 2013-2015 Grega Pompe <grega.pompe@informa.si>
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/CountryName.pm
+++ b/lib/Template/Flute/Filter/CountryName.pm
@@ -75,7 +75,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2012-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2012-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/Currency.pm
+++ b/lib/Template/Flute/Filter/Currency.pm
@@ -54,7 +54,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2011 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2011-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/Date.pm
+++ b/lib/Template/Flute/Filter/Date.pm
@@ -131,7 +131,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2011 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2011-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/Eol.pm
+++ b/lib/Template/Flute/Filter/Eol.pm
@@ -59,7 +59,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2011 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2011-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/LanguageName.pm
+++ b/lib/Template/Flute/Filter/LanguageName.pm
@@ -78,7 +78,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2012-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2012-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/LowerDash.pm
+++ b/lib/Template/Flute/Filter/LowerDash.pm
@@ -35,7 +35,7 @@ William Carr (Mr. Maloof), <bill@bottlenose-wine.com>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2011 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2011-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/NobreakSingle.pm
+++ b/lib/Template/Flute/Filter/NobreakSingle.pm
@@ -43,7 +43,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2011 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2011-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/Replace.pm
+++ b/lib/Template/Flute/Filter/Replace.pm
@@ -66,7 +66,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2012-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2012-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/Strip.pm
+++ b/lib/Template/Flute/Filter/Strip.pm
@@ -37,7 +37,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2013-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2013-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Filter/Upper.pm
+++ b/lib/Template/Flute/Filter/Upper.pm
@@ -33,7 +33,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2011 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2011-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Form.pm
+++ b/lib/Template/Flute/Form.pm
@@ -420,7 +420,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/HTML.pm
+++ b/lib/Template/Flute/HTML.pm
@@ -919,7 +919,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/I18N.pm
+++ b/lib/Template/Flute/I18N.pm
@@ -80,7 +80,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Increment.pm
+++ b/lib/Template/Flute/Increment.pm
@@ -93,7 +93,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Iterator.pm
+++ b/lib/Template/Flute/Iterator.pm
@@ -173,7 +173,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Iterator/Cache.pm
+++ b/lib/Template/Flute/Iterator/Cache.pm
@@ -120,7 +120,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2014-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Iterator/JSON.pm
+++ b/lib/Template/Flute/Iterator/JSON.pm
@@ -163,7 +163,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2011 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2011-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Iterator/Rose.pm
+++ b/lib/Template/Flute/Iterator/Rose.pm
@@ -130,7 +130,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/List.pm
+++ b/lib/Template/Flute/List.pm
@@ -456,7 +456,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Pager.pm
+++ b/lib/Template/Flute/Pager.pm
@@ -218,7 +218,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Paginator.pm
+++ b/lib/Template/Flute/Paginator.pm
@@ -216,7 +216,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Specification.pm
+++ b/lib/Template/Flute/Specification.pm
@@ -701,7 +701,7 @@ Please report any bugs or feature requests at L<https://github.com/racke/Templat
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2015 Stefan Hornburg (Racke).
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Specification.pm
+++ b/lib/Template/Flute/Specification.pm
@@ -701,7 +701,7 @@ Please report any bugs or feature requests at L<https://github.com/racke/Templat
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke).
+Copyright 2010-2015 Stefan Hornburg (Racke).
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Specification/Scoped.pm
+++ b/lib/Template/Flute/Specification/Scoped.pm
@@ -189,7 +189,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Specification/XML.pm
+++ b/lib/Template/Flute/Specification/XML.pm
@@ -361,7 +361,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/UriAdjust.pm
+++ b/lib/Template/Flute/UriAdjust.pm
@@ -110,7 +110,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2014-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/lib/Template/Flute/Utils.pm
+++ b/lib/Template/Flute/Utils.pm
@@ -71,7 +71,7 @@ Stefan Hornburg (Racke), <racke@linuxia.de>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2010-2014 Stefan Hornburg (Racke) <racke@linuxia.de>.
+Copyright 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published

--- a/scripts/flute
+++ b/scripts/flute
@@ -1,6 +1,6 @@
 #! /usr/bin/env perl
 #
-# Copyright (C) 2010-2013 Stefan Hornburg (Racke) <racke@linuxia.de>.
+# Copyright (C) 2010-2015 Stefan Hornburg (Racke) <racke@linuxia.de>.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/t/files/utf8.html
+++ b/t/files/utf8.html
@@ -1,1 +1,1 @@
-<span class="copyright">Copyright © 2011. All rights reserved.</span>
+<span class="copyright">Copyright © 2011-2015. All rights reserved.</span>


### PR DESCRIPTION
The copyright year has been updated in all copyright statements.  Also, the author's email address was added to copyright statements where this was missing in order to be consistent with the rest of the code.