### PR TITLE
Add missing strictures to Template::Flute::Filter::JsonVar

### DIFF
--- a/lib/Template/Flute/Filter/JsonVar.pm
+++ b/lib/Template/Flute/Filter/JsonVar.pm
@@ -1,5 +1,8 @@
 package Template::Flute::Filter::JsonVar;
 
+use strict;
+use warnings;
+
 use base 'Template::Flute::Filter';
 use JSON;
 


### PR DESCRIPTION
CPANTS notes in the Core and Extra metrics that `use strict` and `use warnings` strictures are missing in `Template::Flute`.  It turns out these strictures were only missing from the one package within the distribution.