### PR TITLE
Add more tests for Template::Flute::Iterator::JSON

### DIFF
--- a/t/iterators/20-json.t
+++ b/t/iterators/20-json.t
@@ -15,7 +15,7 @@ if ($@) {
 
 require Template::Flute::Iterator::JSON;
 
-plan tests => 7;
+plan tests => 9;
 
 my ($json, $json_iter);
 
@@ -65,4 +65,65 @@ subtest "Read JSON from file" => sub {
         eval {Template::Flute::Iterator::JSON->new() };
         like $@, qr/Missing JSON file/, "Fails without JSON string, ref or file";
     }
+};
+
+subtest "Selector option" => sub {
+    plan tests => 8;
+
+    my $json = q{[
+    {"sku": "orange", "images": ["orange.jpg", "orange.png"]},
+    {"sku": "pomelo", "images": ["pomelo.jpg", "pomelo.png"]}
+    ]};
+
+    my ($json_fh, $json_file) = tempfile;
+    print $json_fh $json, "\n";
+    close $json_fh;
+
+    my $json_file_iter = Template::Flute::Iterator::JSON->new(
+        file => $json_file, selector => 'unknown');
+    isa_ok $json_file_iter, 'Template::Flute::Iterator';
+    is $json_file_iter->count, 0, "Unknown selector seeds iterator with empty list";
+
+    $json_file_iter = Template::Flute::Iterator::JSON->new(
+        file => $json_file, selector => 'sku', children => 'unknown');
+    isa_ok $json_file_iter, 'Template::Flute::Iterator';
+    is $json_file_iter->count, 0, "Unknown children seeds iterator with empty list";
+
+    my %selector = ('sku' => "unknown");
+    $json_file_iter = Template::Flute::Iterator::JSON->new(
+        file => $json_file, selector => \%selector, children => 'images');
+    isa_ok $json_file_iter, 'Template::Flute::Iterator';
+    is $json_file_iter->count, undef,
+        "Unknown selector value returns undef";
+
+    %selector = ('sku' => "orange");
+    $json_file_iter = Template::Flute::Iterator::JSON->new(
+        file => $json_file, selector => \%selector, children => 'images');
+    isa_ok $json_file_iter, 'Template::Flute::Iterator';
+    is $json_file_iter->count, 2,
+        "Known children seeds iterator number of child elements in slected element";
+};
+
+subtest "'*' selector option" => sub {
+    plan tests => 4;
+
+    my $json = q{[
+    {"sku": "orange", "images": ["orange.jpg", "orange.png"]},
+    {"sku": "pomelo", "images": ["pomelo.jpg", "pomelo.png"]}
+    ]};
+
+    my ($json_fh, $json_file) = tempfile;
+    print $json_fh $json, "\n";
+    close $json_fh;
+
+    my $json_file_iter = Template::Flute::Iterator::JSON->new(
+        file => $json_file, selector => '*', children => 'unknown');
+    isa_ok $json_file_iter, 'Template::Flute::Iterator';
+    is $json_file_iter->count, 0, "Unknown children seeds iterator with empty list";
+
+    $json_file_iter = Template::Flute::Iterator::JSON->new(
+        file => $json_file, selector => '*', children => 'images');
+    isa_ok $json_file_iter, 'Template::Flute::Iterator';
+    is $json_file_iter->count, 4,
+        "Known children seeds iterator with total number of children elements";
 };

--- a/t/iterators/20-json.t
+++ b/t/iterators/20-json.t
@@ -5,6 +5,7 @@
 use strict;
 use warnings;
 use Test::More;
+use File::Temp qw(tempfile);
 
 eval "use JSON";
 
@@ -14,7 +15,7 @@ if ($@) {
 
 require Template::Flute::Iterator::JSON;
 
-plan tests => 6;
+plan tests => 7;
 
 my ($json, $json_iter);
 
@@ -40,3 +41,28 @@ isa_ok($json_iter, 'Template::Flute::Iterator');
 ok($json_iter->count == 2);
 
 isa_ok($json_iter->next, 'HASH');
+
+# JSON from file
+subtest "Read JSON from file" => sub {
+    plan tests => 5;
+
+    my ($json_fh, $json_file) = tempfile;
+    print $json_fh $json, "\n";
+    close $json_fh;
+    my $json_file_iter = Template::Flute::Iterator::JSON->new(file => $json_file);
+
+    isa_ok $json_file_iter, 'Template::Flute::Iterator';
+    is $json_iter->count, 2, "Iterator count is correct";
+    isa_ok $json_iter->next, 'HASH', "Next item is a hash";
+
+    {
+        eval {Template::Flute::Iterator::JSON->new(file => "non-existent-file") };
+        like $@, qr/failed to open JSON file non-existent-file/,
+            "Fails with expected message when file doesn't exist";
+    }
+
+    {
+        eval {Template::Flute::Iterator::JSON->new() };
+        like $@, qr/Missing JSON file/, "Fails without JSON string, ref or file";
+    }
+};


### PR DESCRIPTION
I noticed that the code coverage for `Template::Flute::Iterator::JSON` was at roughly 33% and thought I'd add some more tests.  These tests bring the coverage over 90%.  I've got a few questions about the remaining parts of the code, which I'll ask via IRC when I get the time (and you have time, of course!).

Comments or questions about the PR are most certainly welcome!