### PR TITLE
Check utf8 JSON input in Iterator::JSON

### DIFF
--- a/t/iterators/20-json.t
+++ b/t/iterators/20-json.t
@@ -52,8 +52,8 @@ subtest "Read JSON from file" => sub {
     my $json_file_iter = Template::Flute::Iterator::JSON->new(file => $json_file);
 
     isa_ok $json_file_iter, 'Template::Flute::Iterator';
-    is $json_iter->count, 2, "Iterator count is correct";
-    isa_ok $json_iter->next, 'HASH', "Next item is a hash";
+    is $json_file_iter->count, 2, "Iterator count is correct";
+    isa_ok $json_file_iter->next, 'HASH', "Next item is a hash";
 
     {
         eval {Template::Flute::Iterator::JSON->new(file => "non-existent-file") };

--- a/t/iterators/20-json.t
+++ b/t/iterators/20-json.t
@@ -15,34 +15,30 @@ if ($@) {
 
 require Template::Flute::Iterator::JSON;
 
-plan tests => 9;
+plan tests => 5;
 
-my ($json, $json_iter);
-
-$json = q{[
+my $json = q{[
 {"sku": "orange", "image": "orange.jpg"},
 {"sku": "pomelo", "image": "pomelo.jpg"}
 ]};
 
-# JSON string as is
-$json_iter = Template::Flute::Iterator::JSON->new($json);
+subtest "JSON string as is" => sub {
+    my $json_iter = Template::Flute::Iterator::JSON->new($json);
 
-isa_ok($json_iter, 'Template::Flute::Iterator');
+    isa_ok($json_iter, 'Template::Flute::Iterator');
 
-ok($json_iter->count == 2);
+    ok($json_iter->count == 2);
 
-isa_ok($json_iter->next, 'HASH');
+    isa_ok($json_iter->next, 'HASH');
+};
 
-# JSON string as scalar
-$json_iter = Template::Flute::Iterator::JSON->new(\$json);
+subtest "JSON string as scalar" => sub {
+    my $json_iter = Template::Flute::Iterator::JSON->new(\$json);
+    isa_ok($json_iter, 'Template::Flute::Iterator');
+    ok($json_iter->count == 2);
+    isa_ok($json_iter->next, 'HASH');
+};
 
-isa_ok($json_iter, 'Template::Flute::Iterator');
-
-ok($json_iter->count == 2);
-
-isa_ok($json_iter->next, 'HASH');
-
-# JSON from file
 subtest "Read JSON from file" => sub {
     plan tests => 5;
 


### PR DESCRIPTION
These commits fix a bug in PR #116, localise the variables in the `Iterator::JSON` tests, and add tests for utf8 input as mentioned in the closing comments of PR #116.