### PR TITLE
Fix typo in Iterator::Flute tests

### DIFF
--- a/t/iterators/20-json.t
+++ b/t/iterators/20-json.t
@@ -72,7 +72,7 @@ subtest "Read UTF8 JSON from file" => sub {
     {"sku": "Fußgängerübergänge", "images": ["surépaisseur.jpg", "transición.png"]}
     ]};
     my ($json_fh, $json_file) = tempfile;
-    binmode( $json_fh, ":enoding(UTF-8)" );
+    binmode( $json_fh, ":encoding(UTF-8)" );
     print $json_fh $json, "\n";
     close $json_fh;
     my $json_file_iter = Template::Flute::Iterator::JSON->new(file => $json_file);


### PR DESCRIPTION
How this one slipped through the net I don't know.  I ran the tests and
everything looked ok.  It must have been too late at night or something and
I just missed it, sorry!