### PR TITLE
Use Class::Load instead of eval { use Class::Name }

### DIFF
--- a/t/02-configscoped.t
+++ b/t/02-configscoped.t
@@ -5,12 +5,10 @@
 use strict;
 use warnings;
 use Test::More;
+use Class::Load qw(try_load_class);
 
-eval "use Config::Scoped";
-
-if ($@) {
-	plan skip_all => "No Config::Scoped module.";
-}
+try_load_class('Config::Scoped')
+    or plan skip_all => "No Config::Scoped module.";
 
 plan tests => 3;
 

--- a/t/filters/currency.t
+++ b/t/filters/currency.t
@@ -8,12 +8,10 @@ use warnings;
 use POSIX;
 use Test::More;
 use Template::Flute;
+use Class::Load qw(try_load_class);
 
-eval "use Number::Format";
-
-if ($@) {
-    plan skip_all => "Missing Number::Format module.";
-}
+try_load_class('Number::Format')
+    or plan skip_all => "Missing Number::Format module.";
 
 plan tests => 3;
 

--- a/t/filters/date.t
+++ b/t/filters/date.t
@@ -8,18 +8,13 @@ use warnings;
 use Test::More;
 use Test::Fatal;
 use Template::Flute;
+use Class::Load qw(try_load_class);
 
-eval "use DateTime";
+try_load_class('DateTime')
+    or plan skip_all => "Missing DateTime module.";
 
-if ($@) {
-    plan skip_all => "Missing DateTime module.";
-}
-
-eval "use DateTime::Format::ISO8601";
-
-if ($@) {
-    plan skip_all => "Missing DateTime::Format::ISO8601 module.";
-}
+try_load_class('DateTime::Format::ISO8601')
+    or plan skip_all => "Missing DateTime::Format::ISO8601 module.";
 
 plan tests => 9;
 

--- a/t/filters/json.t
+++ b/t/filters/json.t
@@ -7,12 +7,10 @@ use warnings;
 
 use Test::More;
 use Template::Flute;
+use Class::Load qw(try_load_class);
 
-eval "use JSON";
-
-if ($@) {
-    plan skip_all => "Missing JSON module.";
-}
+try_load_class('JSON')
+    or plan skip_all => "Missing JSON module.";
 
 plan tests => 2;
 

--- a/t/iterators/20-json.t
+++ b/t/iterators/20-json.t
@@ -6,12 +6,10 @@ use strict;
 use warnings;
 use Test::More;
 use File::Temp qw(tempfile);
+use Class::Load qw(try_load_class);
 
-eval "use JSON";
-
-if ($@) {
-	plan skip_all => "No JSON module.";
-}
+try_load_class('JSON')
+    or plan skip_all => "No JSON module.";
 
 require Template::Flute::Iterator::JSON;
 

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -3,11 +3,15 @@
 use strict;
 use warnings;
 use Test::More;
+use Class::Load qw(try_load_class);
 
 unless ( $ENV{RELEASE_TESTING} ) {
     plan( skip_all => "Author tests not required for installation" );
 }
 
-eval "use Test::CheckManifest 0.9";
-plan skip_all => "Test::CheckManifest 0.9 required" if $@;
+try_load_class('Test::CheckManifest', {-version => 0.9})
+    or plan skip_all => "Test::CheckManifest 0.9 required";
+# T::CM imports its functions into the caller's scope, hence, in order to
+# use the test functions, we still need to 'use' it.
+use Test::CheckManifest;
 ok_manifest();

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Class::Load qw(try_load_class);
 
 unless ( $ENV{RELEASE_TESTING} ) {
     plan( skip_all => "Author tests not required for installation" );
@@ -8,15 +9,16 @@ unless ( $ENV{RELEASE_TESTING} ) {
 
 # Ensure a recent version of Test::Pod::Coverage
 my $min_tpc = 1.08;
-eval "use Test::Pod::Coverage $min_tpc";
-plan skip_all => "Test::Pod::Coverage $min_tpc required for testing POD coverage"
-    if $@;
+try_load_class('Test::Pod::Coverage', {-version => $min_tpc})
+    or plan skip_all => "Test::Pod::Coverage $min_tpc required for testing POD coverage";
+# T::P::C imports its functions into the caller's scope, hence, in order to
+# use the test functions, we still need to 'use' it.
+use Test::Pod::Coverage;
 
 # Test::Pod::Coverage doesn't require a minimum Pod::Coverage version,
 # but older versions don't recognize some common documentation styles
 my $min_pc = 0.18;
-eval "use Pod::Coverage $min_pc";
-plan skip_all => "Pod::Coverage $min_pc required for testing POD coverage"
-    if $@;
+try_load_class('Pod::Coverage', {-version => $min_pc})
+    or plan skip_all => "Pod::Coverage $min_pc required for testing POD coverage";
 
 all_pod_coverage_ok({also_private => ['BUILDARGS'],});

--- a/t/pod.t
+++ b/t/pod.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Class::Load qw(try_load_class);
 
 unless ( $ENV{RELEASE_TESTING} ) {
     plan( skip_all => "Author tests not required for installation" );
@@ -10,7 +11,10 @@ unless ( $ENV{RELEASE_TESTING} ) {
 
 # Ensure a recent version of Test::Pod
 my $min_tp = 1.22;
-eval "use Test::Pod $min_tp";
-plan skip_all => "Test::Pod $min_tp required for testing POD" if $@;
+try_load_class('Test::Pod', {-version => $min_tp})
+    or plan skip_all => "Test::Pod $min_tp required for testing POD";
+# T::P imports its functions into the caller's scope, hence, in order to
+# use the test functions, we still need to 'use' it.
+use Test::Pod;
 
 all_pod_files_ok();

--- a/t/values/skip-empty.t
+++ b/t/values/skip-empty.t
@@ -5,6 +5,7 @@ use warnings;
 use Template::Flute;
 use Test::More tests => 5;
 use Data::Dumper;
+use Class::Load qw(try_load_class);
 
 my ($spec, $html, $flute, $out, $expected);
 
@@ -198,11 +199,8 @@ $expected =~ s/\n//g;
 like $out, qr/\Q$expected\E/, "Params as expected" or diag $out;
 
 subtest 'currency_filter' => sub {
-    eval "use Number::Format";
-
-    if ($@) {
-        plan skip_all => "Missing Number::Format module.";
-    }
+    try_load_class('Number::Format')
+        or plan skip_all => "Missing Number::Format module.";
 
     $spec =<<'SPEC';
 <specification>


### PR DESCRIPTION
This change replaces all instances of `eval { 'use Class::Name' } with the
relevant call to `try_load_class()` from `Class::Load`.  The change thus
addresses issue #117.