### PR TITLE
Convert plain 'utf8' to 'encoding(utf-8)'

### DIFF
--- a/t/checking/basic.t
+++ b/t/checking/basic.t
@@ -8,9 +8,9 @@ use Test::More tests => 9;
 use Test::Deep;
 
 my $builder = Test::More->builder;
-binmode $builder->output,         ":utf8";
-binmode $builder->failure_output, ":utf8";
-binmode $builder->todo_output,    ":utf8";
+binmode $builder->output,         ":encoding(utf-8)";
+binmode $builder->failure_output, ":encoding(utf-8)";
+binmode $builder->todo_output,    ":encoding(utf-8)";
 
 use Template::Flute;
 use Data::Dumper;

--- a/t/values/bom.t
+++ b/t/values/bom.t
@@ -11,9 +11,9 @@ use Test::More tests => 4;
 use Data::Dumper;
 
 my $builder = Test::More->builder;
-binmode $builder->output,         ":utf8";
-binmode $builder->failure_output, ":utf8";
-binmode $builder->todo_output,    ":utf8";
+binmode $builder->output,         ":encoding(utf-8)";
+binmode $builder->failure_output, ":encoding(utf-8)";
+binmode $builder->todo_output,    ":encoding(utf-8)";
 
 
 foreach my $html_file ('bom.html', 'bom-included.html') {

--- a/t/values/nbsp.t
+++ b/t/values/nbsp.t
@@ -10,9 +10,9 @@ use utf8;
 use Test::More tests => 10;
 
 my $builder = Test::More->builder;
-binmode $builder->output,         ":utf8";
-binmode $builder->failure_output, ":utf8";
-binmode $builder->todo_output,    ":utf8";
+binmode $builder->output,         ":encoding(utf-8)";
+binmode $builder->failure_output, ":encoding(utf-8)";
+binmode $builder->todo_output,    ":encoding(utf-8)";
 
 
 use Template::Flute;


### PR DESCRIPTION
According to perlcritic, this is better as it gives strict validation.