### PR TITLE
Use full package name for test functions not imported into test script

### DIFF
--- a/t/manifest.t
+++ b/t/manifest.t
@@ -11,7 +11,4 @@ unless ( $ENV{RELEASE_TESTING} ) {
 
 try_load_class('Test::CheckManifest', {-version => 0.9})
     or plan skip_all => "Test::CheckManifest 0.9 required";
-# T::CM imports its functions into the caller's scope, hence, in order to
-# use the test functions, we still need to 'use' it.
-use Test::CheckManifest;
-ok_manifest();
+Test::CheckManifest::ok_manifest();

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -11,9 +11,6 @@ unless ( $ENV{RELEASE_TESTING} ) {
 my $min_tpc = 1.08;
 try_load_class('Test::Pod::Coverage', {-version => $min_tpc})
     or plan skip_all => "Test::Pod::Coverage $min_tpc required for testing POD coverage";
-# T::P::C imports its functions into the caller's scope, hence, in order to
-# use the test functions, we still need to 'use' it.
-use Test::Pod::Coverage;
 
 # Test::Pod::Coverage doesn't require a minimum Pod::Coverage version,
 # but older versions don't recognize some common documentation styles
@@ -21,4 +18,4 @@ my $min_pc = 0.18;
 try_load_class('Pod::Coverage', {-version => $min_pc})
     or plan skip_all => "Pod::Coverage $min_pc required for testing POD coverage";
 
-all_pod_coverage_ok({also_private => ['BUILDARGS'],});
+Test::Pod::Coverage::all_pod_coverage_ok({also_private => ['BUILDARGS'],});

--- a/t/pod.t
+++ b/t/pod.t
@@ -13,8 +13,5 @@ unless ( $ENV{RELEASE_TESTING} ) {
 my $min_tp = 1.22;
 try_load_class('Test::Pod', {-version => $min_tp})
     or plan skip_all => "Test::Pod $min_tp required for testing POD";
-# T::P imports its functions into the caller's scope, hence, in order to
-# use the test functions, we still need to 'use' it.
-use Test::Pod;
 
-all_pod_files_ok();
+Test::Pod::all_pod_files_ok();


### PR DESCRIPTION
…t scope

It turns out the workaround I was using to get test functions such as
`ok_manifest` and `all_pod_coverage_ok` imported into the current scope so
that when `RELEASE_TESTING` was set, the modules would be loaded and the
correct functions run.  Unfortunately, this was incorrect.  All `use`
statements are run at script compile time (they run in effectively a `BEGIN`
block).  Unfortunately, my testing didn't check the case when the modules
were not locally installed; when the relevant modules (e.g.
Test::CheckManifest) are installed, then everything works fine, both with and
without `RELEASE_TESTING`.  Fortunately, upon working on another pull
request, Travis showed up the issue.

The workaround I'm now using -- since `ok_manifest` is not seen in the
`main` scope (due to `try_load_class` effectively running `require` and not
`use`) -- is to use the complete package path to the relevant test
functions.  It's not pretty, but it works in the cases I mention above,
namely with and without `RELEASE_TESTING` and with and without the required
modules being installed.

My apologies for the hassle!