### PR TITLE
Use Travis containers when running CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: perl
 perl:
   - "5.21"


### PR DESCRIPTION
The Travis jobs currently run on legacy infrastructure, which is not
container-based and not what Travis-CI recommends for use anymore.  For
projects not requiring `sudo` access, then the container infrastructure
should be used.  This is achieved by setting `sudo: false` in the
`.travis.yml` file.
