### PR TITLE
Remove superfluous arg shift onto $class variable

### DIFF
--- a/lib/Template/Flute/Container.pm
+++ b/lib/Template/Flute/Container.pm
@@ -25,8 +25,6 @@ sub new {
 	my ($class, $sob, $spec, $name) = @_;
 	my ($self);
 	
-	$class = shift;
-	
 	$self = {sob => $sob};
 
 	bless $self;

--- a/lib/Template/Flute/Form.pm
+++ b/lib/Template/Flute/Form.pm
@@ -20,7 +20,6 @@ sub new {
 	my ($class, $sob, $static) = @_;
 	my ($self);
 	
-	$class = shift;
 	$self = {sob => $sob, static => $static, valid_input => undef};
 
     # retrieve values for action and method attributes

--- a/lib/Template/Flute/List.pm
+++ b/lib/Template/Flute/List.pm
@@ -20,7 +20,6 @@ sub new {
 	my ($class, $sob, $static, $spec, $name) = @_;
 	my ($self, $lf);
 	
-	$class = shift;
 	$static ||= [];
 	
 	$self = {sob => $sob, static => $static, valid_input => undef};


### PR DESCRIPTION
This already happens when unpacking `@_`.