### PR TITLE
Use two argument form of bless

### DIFF
--- a/lib/Template/Flute/Container.pm
+++ b/lib/Template/Flute/Container.pm
@@ -27,7 +27,7 @@ sub new {
 	
 	$self = {sob => $sob};
 
-	bless $self;
+	bless $self, $class;
 	
 	return $self;
 }

--- a/lib/Template/Flute/Form.pm
+++ b/lib/Template/Flute/Form.pm
@@ -41,7 +41,7 @@ sub new {
         $self->{method} = 'GET';
     }
 
-	bless $self;
+	bless $self, $class;
 }
 
 =head1 METHODS

--- a/lib/Template/Flute/HTML.pm
+++ b/lib/Template/Flute/HTML.pm
@@ -47,7 +47,7 @@ sub new {
 	$self = {%args, containers => {}, lists => {}, pagings => {}, forms => {},
 			 params => {}, values => {}, query => {}, file => undef};
 	
-	bless $self;
+	bless $self, $class;
 }
 
 =head1 METHODS

--- a/lib/Template/Flute/Increment.pm
+++ b/lib/Template/Flute/Increment.pm
@@ -55,7 +55,7 @@ sub new {
 		$self->{increment} = 1;
 	}
 	
-	bless $self;
+	bless $self, $class;
 
 	return $self;
 }

--- a/lib/Template/Flute/List.pm
+++ b/lib/Template/Flute/List.pm
@@ -29,7 +29,7 @@ sub new {
 	}
     $self->{limit} = $sob->{limit} if defined $sob->{limit};
 	
-	bless $self;
+	bless $self, $class;
 	
 	if ($spec && $name) {
 		$self->inputs_add($spec->list_inputs($name));

--- a/lib/Template/Flute/Specification.pm
+++ b/lib/Template/Flute/Specification.pm
@@ -55,7 +55,7 @@ sub new {
     # named patterns
     $self->{patterns} = {};
 
-	bless $self;
+	bless $self, $class;
 }
 
 sub _ids {

--- a/lib/Template/Flute/Specification/XML.pm
+++ b/lib/Template/Flute/Specification/XML.pm
@@ -36,7 +36,7 @@ sub new {
 	%params = @_;
 
 	$self = \%params;
-	bless $self;
+	bless $self, $class;
 }
 
 =head1 METHODS


### PR DESCRIPTION
This is better practice as it ensures that the object is blessed into the
class that is intended.  See also PBP page 365.