### PR TITLE
Fix Pager class docs

### DIFF
--- a/lib/Template/Flute/Pager.pm
+++ b/lib/Template/Flute/Pager.pm
@@ -12,23 +12,23 @@ Template::Flute::Pager - Data::Page class for Template::Flute
 
 =head1 SYNOPSIS
 
-    $paginator = Template::Flute::Paginator->new;
+    $pager = Template::Flute::Pager->new;
 
     # set page size
-    $paginator->page_size(10);
+    $pager->page_size(10);
 
     # retrieve number of pages
-    $paginator->pages;
+    $pager->pages;
 
-    # retrieve current page (starting with 1)
-    $paginator->current_page;
+    # retrieve current page (numering starts at 1)
+    $pager->current_page;
 
     # retrieve global position numbers for current page
-    $paginator->position_first;
-    $paginator->position_last;
+    $pager->position_first;
+    $pager->position_last;
 
-    # select a page (starting with 1)
-    $paginator->select_page;
+    # select a page (numbering starts at 1)
+    $pager->select_page(5);
 
 =head1 ATTRIBUTES
 

--- a/lib/Template/Flute/Pager.pm
+++ b/lib/Template/Flute/Pager.pm
@@ -112,7 +112,7 @@ sub current_page {
 
 =head2 select_page {
 
-Select page, starting from 1.
+Select page.  Page numbering starts at 1.
 
 =cut
 
@@ -125,6 +125,8 @@ sub select_page {
 
 =head2 position_first
 
+Returns global position number of first item on current page.
+
 =cut
 
 sub position_first {
@@ -134,6 +136,8 @@ sub position_first {
 }
 
 =head2 position_last
+
+Returns global position number of last item on current page.
 
 =cut
 


### PR DESCRIPTION
The `Pager` class docs were incorrectly referring to the `Paginator` class; this is fixed in these changes.  Also missing method descriptions have been added.