### PR TITLE
Remove Flute::Form->finalize

### DIFF
--- a/lib/Template/Flute/Form.pm
+++ b/lib/Template/Flute/Form.pm
@@ -354,24 +354,6 @@ sub fill {
 	}
 }
 
-=head2 finalize ELT
-
-Finalizes form.
-
-=cut
-
-sub finalize {
-	my ($self, $elt) = @_;
-
-	for (qw/action method/) {
-		if (exists $self->{$_} && $self->{$_}) {
-			$elt->set_att($_, $self->{$_});
-		}
-	}
-
-	return;
-}
-
 =head2 query
 
 Returns Perl structure for database query based on


### PR DESCRIPTION
This method isn't used anywhere else in the code.  In fact, a `git grep finalize` on the codebase showed that the word `finalize` only occured in the definition of this method and in its documentation.  Since it doesn't seem to be needed, my recommendation is to remove it.
