### PR TITLE
switch Form->action to immutable and remove private writer method

### DIFF
--- a/lib/Template/Flute/Form.pm
+++ b/lib/Template/Flute/Form.pm
@@ -28,12 +28,24 @@ has name => (
 
 Form action.
 
+=over
+
+=item writer: set_action
+
+=back
+
 =cut
 
 has action => (
-    is => 'rwp',
+    is => 'ro',
     default => '',
+    writer  => 'set_action',
 );
+
+after 'set_action' => sub {
+    my ( $self, $arg ) = @_;
+    $self->elt->set_att( 'action', $arg );
+};
 
 =head2 method
 
@@ -224,20 +236,6 @@ sub iterators {
     }
 
     return \%iterators;
-}
-
-
-=head2 set_action ACTION
-
-Sets from action to ACTION.
-
-=cut
-
-sub set_action {
-	my ($self, $action) = @_;
-
-	$self->elt->set_att('action', $action);
-	$self->_set_action($action);
 }
 
 =head2 set_method METHOD


### PR DESCRIPTION
Old set_action method now implemented via writer option in atrtribute
definition along with 'after' modifier to update action in twig elt. Now
it is not possible for subclass to alter value of action without
updating the associated twig elt. Adds safety and reduces line count.